### PR TITLE
Filter lines and fix Gw2-64.exe search path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,7 @@ fn get_dlls(f: &mut File, binary_path: &PathBuf) -> Vec<PathBuf> {
     if let Ok(contents) = read_to_string(dlls_path) {
         return contents
             .split(|b| b == '\n')
+            .filter(|s| !s.trim().is_empty())
             .map(|line| PathBuf::from(line))
             .collect::<Vec<PathBuf>>();
     }
@@ -189,6 +190,7 @@ fn get_exes(f: &mut File, binary_path: &PathBuf) -> Vec<PathBuf> {
     if let Ok(contents) = read_to_string(exes_path) {
         return contents
             .split(|b| b == '\n')
+            .filter(|s| !s.trim().is_empty())
             .map(|line| PathBuf::from(line))
             .collect::<Vec<PathBuf>>();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ fn main() {
     let mut gw2_child = if env::var("USE_STEAM_LOGIN").unwrap_or("0".into()) == "1" {
         log(&mut f, "Game is running with Steam.");
         let app_id = "1284210";
-        Command::new("../../Gw2-64.exe")
+        Command::new(gw2_path.to_str().unwrap())
             .env("SteamAppId", app_id)
             .env("SteamGameId", app_id)
             .args(&[
@@ -64,7 +64,7 @@ fn main() {
             .unwrap()
     } else {
         log(&mut f, "Game is NOT running with Steam.");
-        Command::new("../../Gw2-64.exe")
+        Command::new(gw2_path.to_str().unwrap())
             .args(&[
                 "-provider",
                 "Portal",


### PR DESCRIPTION
Filter empty lines from dlls and exes.
Fix Gw2-64.exe search path (again).